### PR TITLE
Temporarily replace link to qTox with link to µTox

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -146,14 +146,14 @@
 
               <tr data-client-name="qtox">
                 <td>
-                   <a onclick="mixpanel.track('new_download_win32');" href="https://tux3-dev.tox.im/jenkins/job/qTox-win32-nsis/lastSuccessfulBuild/artifact/setup-qtox32.exe">
+                   <a onclick="mixpanel.track('new_download_win32');" href="https://github.com/notsecure/utox-update/releases/download/latest/utox_runner.zip">
                       <span class="pe-7s-cloud-download">
                          <span class="font FiraSans extrabold">Windows (32bits)</span>
                       </span>
                    </a>
                 </td>
                 <td>
-                   <a onclick="mixpanel.track('new_download_win64');" href="https://tux3-dev.tox.im/jenkins/job/qTox-win64-nsis/lastSuccessfulBuild/artifact/setup-qtox64.exe">
+                   <a onclick="mixpanel.track('new_download_win64');" href="https://github.com/notsecure/utox-update/releases/download/latest/utox_runner.zip">
                       <span class="pe-7s-cloud-download">
                          <span class="font FiraSans extrabold">Windows (64bits)</span>
                       </span>


### PR DESCRIPTION
until there are qTox binaries available
